### PR TITLE
fix: incorrect uniform type flags in CoreShader

### DIFF
--- a/coregl-utils/src/main/java/de/lessvoid/coregl/CoreShader.java
+++ b/coregl-utils/src/main/java/de/lessvoid/coregl/CoreShader.java
@@ -1,27 +1,27 @@
 /**
- * Copyright (c) 2013, Jens Hohmuth 
- * All rights reserved. 
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions are 
- * met: 
- * 
- *  * Redistributions of source code must retain the above copyright 
- *    notice, this list of conditions and the following disclaimer. 
- *  * Redistributions in binary form must reproduce the above copyright 
- *    notice, this list of conditions and the following disclaimer in the 
- *    documentation and/or other materials provided with the distribution. 
- * 
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND 
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE 
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+ * Copyright (c) 2013, Jens Hohmuth
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 package de.lessvoid.coregl;
@@ -232,7 +232,7 @@ public class CoreShader {
 	}
 
 	public void setUniformfv(final String name, final int componentNum, final FloatBuffer values) {
-		setUniformv(name, componentNum, UniformType.INT, values);
+		setUniformv(name, componentNum, UniformType.FLOAT, values);
 
 	}
 
@@ -240,12 +240,12 @@ public class CoreShader {
 		DoubleBuffer buff = gl.getUtil().createDoubleBuffer(values.length);
 		buff.put(values);
 		buff.flip();
-		setUniformv(name, componentNum, UniformType.FLOAT, buff);
+		setUniformv(name, componentNum, UniformType.DOUBLE, buff);
 
 	}
 
 	public void setUniformdv(final String name, final int componentNum, final DoubleBuffer values) {
-		setUniformv(name, componentNum, UniformType.INT, values);
+		setUniformv(name, componentNum, UniformType.DOUBLE, values);
 	}
 
 	public void setUniformMatrix(final String name, final int componentNum, final float... values) {
@@ -304,7 +304,7 @@ public class CoreShader {
 		checkGLError(method);
 	}
 
-	private void setUniformv(final String name, final int componentNum, 
+	private void setUniformv(final String name, final int componentNum,
 			final UniformType type, final Buffer data) {
 		int loc = getLocation(name);
 		if(componentNum < 1 || componentNum > 4)


### PR DESCRIPTION
Some of the public setUniform[x] methods were forwarding the wrong UniformType to the internal setter methods, causing method reflection call errors.