### PR TITLE
Fix CoreInputJogl failing to initialize properly.

### DIFF
--- a/coregl-utils-jogl/src/main/java/de/lessvoid/coregl/jogl/input/CoreInputJogl.java
+++ b/coregl-utils-jogl/src/main/java/de/lessvoid/coregl/jogl/input/CoreInputJogl.java
@@ -37,7 +37,7 @@ public class CoreInputJogl extends AbstractCoreInput {
 
   @Override
   public void initialize() {
-    if (eventQueue == null || eventQueue.isRunning()) return;
+    if (eventQueue != null && eventQueue.isRunning()) return;
 
     eventQueue = new PollingEventQueue(this);
     eventQueue.start();


### PR DESCRIPTION
Inverted incorrect logic for null check at beginning of 'initialize' method.